### PR TITLE
Add a shim to include default arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
 # heroku-buildpack-google-chrome
 
-This buildpack installs the latest version of Chrome Canary and makes it available under the `google-chrome-unstable` command.
+This buildpack installs the latest version of Chrome Canary and makes the
+headless version available under the `google-chrome-unstable` command.
 
 ## Notes
 
-Chrome must be started with a few flags to work correctly.
+To run Chrome on a Heroku dyno, it needs to be started in headless mode with
+a few features disabled. This buildpack creates a shim that will add the
+required command line arguments (`--headless`, `--no-sandbox`, and
+`--disable-gpu`) by default.
+
+When running in headless mode, the browser will exit immediately after loading
+the page. You may work around this by using the `--remote-debugging-port` flag.
+For example:
 
 ```sh
-$ google-chrome-unstable --headess --no-sandbox --disable-gpu
-```
-
-When running in headless mode, the browser will exit immediately after loading the page. A work around is to use the `--remote-debugging-port` flag.
-
-```sh
-$ google-chrome-unstable --headess --no-sandbox --disable-gpu --remote-debugging-port=9222
+$ google-chrome-unstable --remote-debugging-port=9222
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -88,7 +88,7 @@ export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPP
 topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
 
-topic "Creating google-chrome-unstable command shim"
+topic "Creating google-chrome-unstable shim"
 SHIM=$BUILD_DIR/.apt/usr/bin/google-chrome-unstable
 rm $SHIM
 cat <<EOF >$SHIM

--- a/bin/compile
+++ b/bin/compile
@@ -93,6 +93,6 @@ SHIM=$BUILD_DIR/.apt/usr/bin/google-chrome-unstable
 rm $SHIM
 cat <<EOF >$SHIM
 #!/usr/bin/env bash
-/app/.apt/opt/google/chrome-unstable/google-chrome-unstable --headless --no-sandbox --disable-gpu $@
+/app/.apt/opt/google/chrome-unstable/google-chrome-unstable --headless --no-sandbox --disable-gpu \$@
 EOF
 chmod +x $SHIM

--- a/bin/compile
+++ b/bin/compile
@@ -88,7 +88,11 @@ export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPP
 topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
 
-topic "Fixing Google Chrome symlinks"
-
-rm $BUILD_DIR/.apt/usr/bin/google-chrome-unstable
-ln -s /app/.apt/opt/google/chrome-unstable/google-chrome-unstable $BUILD_DIR/.apt/usr/bin/google-chrome-unstable
+topic "Creating google-chrome-unstable command shim"
+SHIM=$BUILD_DIR/.apt/usr/bin/google-chrome-unstable
+rm $SHIM
+cat <<EOF >$SHIM
+#!/usr/bin/env bash
+/app/.apt/opt/google/chrome-unstable/google-chrome-unstable --headless --no-sandbox --disable-gpu $@
+EOF
+chmod +x $SHIM


### PR DESCRIPTION
The only way this buildpack will work on a Heroku dyno is by passing `--headless`, `--no-sandbox`, and `--disable-gpu` to the binary. We might as well include these arguments so users don't have to.