### PR TITLE
Use chrome stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,40 @@
 # heroku-buildpack-google-chrome
 
-This buildpack installs the latest version of Chrome Canary and makes the
-headless version available under the `google-chrome-unstable` command.
+This buildpack downloads and installs (headless) Google Chrome from your choice
+of release channels.
 
-## Notes
+## Channels
 
-To run Chrome on a Heroku dyno, it needs to be started in headless mode with
-a few features disabled. This buildpack creates a shim that will add the
-required command line arguments (`--headless`, `--no-sandbox`, and
-`--disable-gpu`) by default.
+You can choose your release channel by specifying `GOOGLE_CHROME_CHANNEL` as
+a config var for your app, in your app.json (for Heroku CI and Review Apps),
+or in your pipeline settings (for Heroku CI).
 
-When running in headless mode, the browser will exit immediately after loading
-the page. You may work around this by using the `--remote-debugging-port` flag.
-For example:
+Valid values are `stable`, `beta`, and `unstable`. If unspecified, the `stable`
+channel will be used.
+
+## Shims and Command Line Flags
+
+This buildpack installs shims that always add `--headless`, `--disable-gpu`,
+and `--no-sandbox` to any `google-chrome` command  as they are required for 
+Chrome to run on a Heroku dyno.
+
+You'll have two of these shims on your path: `google-chrome` and
+`google-chrome-$GOOGLE_CHROME_CHANNEL`. They both point to the binary of
+the selected channel.
+
+## Selenium
+
+If you are using this buildpack with Selenium and webdriver, you'll need to
+tell Selenium where to find the chrome binary. Selenium expects the binary to
+live at `/usr/bin/google-chrome`, but that's a read-only filesystem on Heroku.
+You'll have to tell Selenium and chromedrive that chrome is at
+`/app/.apt/usr/bin/google-chrome`.
+
+## Early termination
+
+This buildpack will run Chrome with the `--headless` flag, so you may have
+issues where Chrome immediately shuts down after your command. You can use
+the `--remote-debugging-port` flag to keep Chrome running. For example:
 
 ```sh
 $ google-chrome-unstable --remote-debugging-port=9222

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ the selected channel.
 If you are using this buildpack with Selenium and webdriver, you'll need to
 tell Selenium where to find the chrome binary. Selenium expects the binary to
 live at `/usr/bin/google-chrome`, but that's a read-only filesystem on Heroku.
-You'll have to tell Selenium and chromedrive that chrome is at
-`/app/.apt/usr/bin/google-chrome`.
+You'll have to tell Selenium and/or chromedriver that Chrome is at
+`/app/.apt/usr/bin/google-chrome` instead.
 
 ## Early termination
 
@@ -37,5 +37,5 @@ issues where Chrome immediately shuts down after your command. You can use
 the `--remote-debugging-port` flag to keep Chrome running. For example:
 
 ```sh
-$ google-chrome-unstable --remote-debugging-port=9222
+$ google-chrome --remote-debugging-port=9222
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -10,9 +10,9 @@ set -e
 # parse and derive params
 BUILD_DIR=$1
 CACHE_DIR=$2
-LP_DIR=`cd $(dirname $0); cd ..; pwd`
+ENV_DIR=$3
 
-PACKAGES="https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb libxss1"
+LP_DIR=`cd $(dirname $0); cd ..; pwd`
 
 function error() {
   echo " !     $*" >&2
@@ -30,6 +30,37 @@ function indent() {
     *)      sed -u "$c";;
   esac
 }
+
+# Detect requested channel or default to stable
+if [ -f $ENV_DIR/GOOGLE_CHROME_CHANNEL ]; then
+  channel=$(cat $ENV_DIR/GOOGLE_CHROME_CHANNEL)
+else
+  channel=stable
+fi
+
+# Setup bin and shim locations for desired channel, and detect invalid channels
+BIN_DIR=$BUILD_DIR/.apt/usr/bin
+case "$channel" in
+  "stable")
+    BIN=/app/.apt/opt/google/chrome/chrome
+    SHIM=$BIN_DIR/google-chrome-stable
+    ;;
+  "beta")
+    BIN=/app/.apt/opt/google/chrome-beta/chrome
+    SHIM=$BIN_DIR/google-chrome-beta
+    ;;
+  "unstable")
+    BIN=/app/.apt/opt/google/chrome-unstable/chrome
+    SHIM=$BIN_DIR/google-chrome-unstable
+    ;;
+  *)
+    error "GOOGLE_CHROME_CHANNEL must be 'stable', 'beta', or 'unstable', not '$channel'"
+    ;;
+esac
+
+indent "Installing Google Chrome from the $channel channel."
+
+PACKAGES="https://dl.google.com/linux/direct/google-chrome-${channel}_current_amd64.deb libxss1"
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
@@ -88,13 +119,12 @@ export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPP
 topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
 
-topic "Creating google-chrome shim"
-BIN_DIR=$BUILD_DIR/.apt/usr/bin
-SHIM=$BIN_DIR/google-chrome-beta
+topic "Creating google-chrome shims"
+
 rm $SHIM
 cat <<EOF >$SHIM
 #!/usr/bin/env bash
-/app/.apt/opt/google/chrome-beta/google-chrome-beta --headless --no-sandbox --disable-gpu \$@
+$BIN --headless --no-sandbox --disable-gpu \$@
 EOF
 chmod +x $SHIM
 cp $SHIM $BIN_DIR/google-chrome


### PR DESCRIPTION
The stable channel of Chrome is now running version 57. The `--headless` flag for Linux was released in version 57, so there should be no need for the beta channel any longer.

Keep in mind that `--headless` is only available on version 59+ for Windows and Mac. So to use `--headless` locally, you may need to still run the canary or dev channel.