### PR TITLE
Use exec in shims

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -124,7 +124,7 @@ topic "Creating google-chrome shims"
 rm $SHIM
 cat <<EOF >$SHIM
 #!/usr/bin/env bash
-$BIN --headless --no-sandbox --disable-gpu \$@
+exec $BIN --headless --no-sandbox --disable-gpu \$@
 EOF
 chmod +x $SHIM
 cp $SHIM $BIN_DIR/google-chrome


### PR DESCRIPTION
Previously, we ran the `google-chrome-stable` command directly in-line, which would start a child process. This worked for most applications, but meant that signals like `SIGTERM` and `SIGKILL` were never passed through to the child process

`exec` replaces the shell without creating a new process, so signals can be passed through. If you were having problems with test runners waiting for Chrome to exit, this will likely fix it.