### PR TITLE
Shim remote debugging port

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ channel will be used.
 
 ## Shims and Command Line Flags
 
-This buildpack installs shims that always add `--headless`, `--disable-gpu`,
-and `--no-sandbox` to any `google-chrome` command  as they are required for 
-Chrome to run on a Heroku dyno.
+This buildpack installs shims that always add `--headless`, `--disable-gpu`, 
+`--no-sandbox`, and `--remote-debugging-port=9222` to any `google-chrome` 
+command as you'll have trouble running Chrome on a Heroku dyno otherwise.
 
 You'll have two of these shims on your path: `google-chrome` and
 `google-chrome-$GOOGLE_CHROME_CHANNEL`. They both point to the binary of
@@ -37,13 +37,3 @@ also available.
 Additionally, chromedriver expects Chrome to be installed at `/usr/bin/google-chrome`,
 but that's a read-only filesystem in a Heroku slug. You'll need to tell Selenium/chromedriver
 that the chrome binary is at `/app/.apt/usr/bin/google-chrome` instead.
-
-## Early termination
-
-This buildpack will run Chrome with the `--headless` flag, so you may have
-issues where Chrome immediately shuts down after your command. You can use
-the `--remote-debugging-port` flag to keep Chrome running. For example:
-
-```sh
-$ google-chrome --remote-debugging-port=9222
-```

--- a/bin/compile
+++ b/bin/compile
@@ -124,7 +124,7 @@ topic "Creating google-chrome shims"
 rm $SHIM
 cat <<EOF >$SHIM
 #!/usr/bin/env bash
-exec $BIN --headless --no-sandbox --disable-gpu \$@
+exec $BIN --headless --no-sandbox --disable-gpu --remote-debugging-port=9222 \$@
 EOF
 chmod +x $SHIM
 cp $SHIM $BIN_DIR/google-chrome


### PR DESCRIPTION
Forgetting to add this is a common gotcha with this buildpack. It frequently causes issues for users, and I have yet to see a use case where it wasn't required.