### PR TITLE
Support both heroku-16 and cedar-14

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,13 +54,27 @@ case "$channel" in
     SHIM=$BIN_DIR/google-chrome-unstable
     ;;
   *)
-    error "GOOGLE_CHROME_CHANNEL must be 'stable', 'beta', or 'unstable', not '$channel'"
+    error "GOOGLE_CHROME_CHANNEL must be 'stable', 'beta', or 'unstable', not '$channel'."
     ;;
+esac
+
+stack=${STACK:-heroku-16}
+
+# Install correct dependencies according to $STACK
+case "$stack" in
+  "cedar-14")
+    PACKAGES="libxss1"
+    ;;
+  "heroku-16")
+    PACKAGES="libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk2.0-0 libxinerama1"
+    ;;
+  *)
+    error "STACK must be 'cedar-14' or 'heroku-16', not '$stack.'"
 esac
 
 indent "Installing Google Chrome from the $channel channel."
 
-PACKAGES="https://dl.google.com/linux/direct/google-chrome-${channel}_current_amd64.deb libxss1"
+PACKAGES="$PACKAGES https://dl.google.com/linux/direct/google-chrome-${channel}_current_amd64.deb"
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"


### PR DESCRIPTION
When using this buildpack on the `heroku-16` stack, `google-chrome` will throw an error like this:

```
/app/.apt/opt/google/chrome/chrome: error while loading shared libraries: libX11-xcb.so.1: cannot open shared object file: No such file or directory
```

`heroku-16` doesn't come with many of the packages we have for `cedar-14`. This PR installs those missing packages if `heroku-16` is detected.