### PR TITLE
Issue with libraries for current beta channel (Chrome Version 59.0.3071.47)

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,7 +66,7 @@ case "$stack" in
     PACKAGES="libxss1"
     ;;
   "heroku-16")
-    PACKAGES="libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk-3-0 libxinerama1"
+    PACKAGES="libcairo-gobject2 libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk-3-0 libxinerama1"
     ;;
   *)
     error "STACK must be 'cedar-14' or 'heroku-16', not '$stack.'"

--- a/bin/compile
+++ b/bin/compile
@@ -66,7 +66,7 @@ case "$stack" in
     PACKAGES="libxss1"
     ;;
   "heroku-16")
-    PACKAGES="libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk2.0-0 libxinerama1"
+    PACKAGES="libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk-3-0 libxinerama1"
     ;;
   *)
     error "STACK must be 'cedar-14' or 'heroku-16', not '$stack.'"

--- a/bin/compile
+++ b/bin/compile
@@ -79,6 +79,8 @@ PACKAGES="$PACKAGES https://dl.google.com/linux/direct/google-chrome-${channel}_
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
 
+rm -rf $APT_CACHE_DIR/archives/*.deb
+
 mkdir -p "$APT_CACHE_DIR/archives/partial"
 mkdir -p "$APT_STATE_DIR/lists/partial"
 


### PR DESCRIPTION
For our project we need the current `beta` channel version of Chrome but a library (libgtk-3.so.o) is missing.
Error appears when trying to launch chrome in bash manually:
```
google-chrome --headless --disable-gpu --remote-debugging-port=9222
/app/.apt/opt/google/chrome-beta/chrome: error while loading shared libraries: libgtk-3.so.0: cannot open shared object file: No such file or directory
```

We fixed it in this PR, but we didn't test if this build now still works for the `stable`channel. Just in case anyone runs into the same problem.