### PR TITLE
Add GOOGLE_CHROME_SHIM

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,9 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+- Added `$GOOGLE_CHROME_SHIM` variable to prevent users from needing to hard-
+  code the shim location.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ use the standard location locally and the custom location on Heroku. An example
 configuration for Ruby's Capybara:
 
 ```
-chrome_bin = ENV.fetch('GOOGLE_CHROME_BIN', nil)
+chrome_bin = ENV.fetch('GOOGLE_CHROME_SHIM', nil)
 
 chrome_opts = chrome_bin ? { "chromeOptions" => { "binary" => chrome_bin } } : {}
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ but that's a read-only filesystem in a Heroku slug. You'll need to tell Selenium
 that the chrome binary is at `/app/.apt/usr/bin/google-chrome` instead.
 
 To make that easier, this buildpack makes `$GOOGLE_CHROME_BIN`, and
-`$GOOGLE_CHROME_SHIM` available as environment variables. With it, you can 
+`$GOOGLE_CHROME_SHIM` available as environment variables. With them, you can 
 use the standard location locally and the custom location on Heroku. An example 
 configuration for Ruby's Capybara:
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Additionally, chromedriver expects Chrome to be installed at `/usr/bin/google-ch
 but that's a read-only filesystem in a Heroku slug. You'll need to tell Selenium/chromedriver
 that the chrome binary is at `/app/.apt/usr/bin/google-chrome` instead.
 
-To make that easier, this buildpack makes `$GOOGLE_CHROME_BIN` available as
-an environment variable. With it, you can use the standard location
-locally and the custom location on Heroku. An example configuration for Ruby's
-Capybara:
+To make that easier, this buildpack makes `$GOOGLE_CHROME_BIN`, and
+`$GOOGLE_CHROME_SHIM` available as environment variables. With it, you can 
+use the standard location locally and the custom location on Heroku. An example 
+configuration for Ruby's Capybara:
 
 ```
 chrome_bin = ENV.fetch('GOOGLE_CHROME_BIN', nil)
@@ -52,7 +52,7 @@ Capybara.register_driver :chrome do |app|
   Capybara::Selenium::Driver.new(
      app,
      browser: :chrome,
-     desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(chrome_options)
+     desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(chrome_opts)
   )
 end
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -147,4 +147,5 @@ cp $SHIM $BIN_DIR/google-chrome
 # about the non-standard location
 cat <<EOF >$BUILD_DIR/.profile.d/010_google-chrome.sh
 export GOOGLE_CHROME_BIN=$BIN
+export GOOGLE_CHROME_SHIM=$SHIM
 EOF


### PR DESCRIPTION
`$GOOGLE_CHROME_BIN` was added with the intention to point at the shim with extra flags, but instead it pointed to the raw binary. To prevent any backwards incompatibility, this adds `$GOOGLE_CHROME_SHIM`.

This also includes a typo in the README directions.