### PR TITLE
Add libcairo-gobject2 package to the build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,7 +66,7 @@ case "$stack" in
     PACKAGES="libxss1"
     ;;
   "heroku-16")
-    PACKAGES="libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk2.0-0 libgtk-3-0 libxinerama1"
+    PACKAGES="libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk2.0-0 libgtk-3-0 libxinerama1 libcairo-gobject2"
     ;;
   *)
     error "STACK must be 'cedar-14' or 'heroku-16', not '$stack.'"


### PR DESCRIPTION
Fixes
```
/app/.apt/opt/google/chrome/chrome:
error while loading shared libraries: libcairo-gobject.so.2: cannot open shared object file:
No such file or directory
```
for any of the build types _(stable, beta or unstable)_