### PR TITLE
Fix Selenium example for Selenium 3.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,16 @@ configuration for Ruby's Capybara:
 ```
 chrome_bin = ENV.fetch('GOOGLE_CHROME_SHIM', nil)
 
-chrome_opts = chrome_bin ? { "chromeOptions" => { "binary" => chrome_bin } } : {}
+options = {}
+options[:args] = ['headless', 'disable-gpu']
+options[:binary] = chrome_bin if chrome_bin
 
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(
-     app,
+Capybara.register_driver :headless_chrome do |app|
+  Capybara::Selenium::Driver.new(app,
      browser: :chrome,
-     desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(chrome_opts)
-  )
+     options: Selenium::WebDriver::Chrome::Options.new(options)
+   )
 end
+
+Capybara.javascript_driver = :headless_chrome
 ```


### PR DESCRIPTION
Selenium Webdriver args have changed so `desired_capabilities` doesn't work in the latest version. I've updated the README example with the new options parameter