### PR TITLE
Add "none" channel to skip Google Chrome's executable download

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@ You can choose your release channel by specifying `GOOGLE_CHROME_CHANNEL` as
 a config var for your app, in your app.json (for Heroku CI and Review Apps),
 or in your pipeline settings (for Heroku CI).
 
-Valid values are `stable`, `beta`, and `unstable`. If unspecified, the `stable`
-channel will be used.
+Valid values are `stable`, `beta`, `unstable`, and `none`. If unspecified, the
+`stable` channel will be used.
+
+By choosing `none` as your release channel, you will need to provide your own
+executable of Google Chrome, however all the packages required to run it
+properly will be installed.
 
 ## Shims and Command Line Flags
 
-This buildpack installs shims that always add `--headless`, `--disable-gpu`, 
-`--no-sandbox`, and `--remote-debugging-port=9222` to any `google-chrome` 
+This buildpack installs shims that always add `--headless`, `--disable-gpu`,
+`--no-sandbox`, and `--remote-debugging-port=9222` to any `google-chrome`
 command as you'll have trouble running Chrome on a Heroku dyno otherwise.
 
 You'll have two of these shims on your path: `google-chrome` and
@@ -39,8 +43,8 @@ but that's a read-only filesystem in a Heroku slug. You'll need to tell Selenium
 that the chrome binary is at `/app/.apt/usr/bin/google-chrome` instead.
 
 To make that easier, this buildpack makes `$GOOGLE_CHROME_BIN`, and
-`$GOOGLE_CHROME_SHIM` available as environment variables. With them, you can 
-use the standard location locally and the custom location on Heroku. An example 
+`$GOOGLE_CHROME_SHIM` available as environment variables. With them, you can
+use the standard location locally and the custom location on Heroku. An example
 configuration for Ruby's Capybara:
 
 ```

--- a/bin/compile
+++ b/bin/compile
@@ -52,8 +52,10 @@ case "$channel" in
     BIN=chrome-unstable/chrome
     SHIM=google-chrome-unstable
     ;;
+  "none")
+    ;;
   *)
-    error "GOOGLE_CHROME_CHANNEL must be 'stable', 'beta', or 'unstable', not '$channel'."
+    error "GOOGLE_CHROME_CHANNEL must be 'stable', 'beta', 'unstable', or 'none', not '$channel'."
     ;;
 esac
 
@@ -71,9 +73,13 @@ case "$stack" in
     error "STACK must be 'cedar-14' or 'heroku-16', not '$stack.'"
 esac
 
-indent "Installing Google Chrome from the $channel channel."
+if [[ $channel != 'none' ]]; then
+  echo "Installing Google Chrome from the $channel channel." | indent
 
-PACKAGES="$PACKAGES https://dl.google.com/linux/direct/google-chrome-${channel}_current_amd64.deb"
+  PACKAGES="$PACKAGES https://dl.google.com/linux/direct/google-chrome-${channel}_current_amd64.deb"
+else
+  echo "Skipping Google Chrome installation due to channel set to 'none'." | indent
+fi
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
@@ -133,6 +139,12 @@ topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'
 
 topic "Creating google-chrome shims"
+
+if [[ $channel == 'none' ]]; then
+  echo "Abort the creation due to channel set to 'none'." | indent
+
+  exit 0
+fi
 
 BIN_DIR=$BUILD_DIR/.apt/usr/bin
 


### PR DESCRIPTION
I have a use case for this when using [Puppeteer](https://github.com/GoogleChrome/puppeteer/) on Heroku. Puppeteer automatically downloads a specific revision of Chromium that is guaranteed to work with the library. As expected, the Chromium executable will not run properly without this buildpack, but downloading Google Chrome **and** Chromium is quite _overkill_. This is what I've created this PR.

By setting `GOOGLE_CHROME_CHANNEL` to `none`, Google Chrome will not be downloaded and the shims will not be created. However, all the required dependencies will be installed and Chromium's executable will run properly.

**Note:** I've tried using Google Chrome's executable with Puppeteer, but the APIs don't match.