### PR TITLE
Added implicit set of javascript driver on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,6 @@ Capybara.register_driver :chrome do |app|
      desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(chrome_opts)
   )
 end
+
+Capybara.javascript_driver = :chrome
 ```


### PR DESCRIPTION
* If the driver for javascript is not implicitly set
  and by any chance you are not using the default driver it
  won't be linked.

* Had this issue myself since i was using the
  ```:selenium_chrome_headless```
  on development and during the ci the ```:chrome``` driver
  that was beeing created was not being linked as the javascript driver