### PR TITLE
Replace deprecated apt "--force-yes" with "--allow" flag

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -127,7 +127,7 @@ for PACKAGE in $PACKAGES; do
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
+    apt-get $APT_OPTIONS -y --allow -d install --reinstall $PACKAGE | indent
   fi
 done
 

--- a/bin/compile
+++ b/bin/compile
@@ -127,7 +127,7 @@ for PACKAGE in $PACKAGES; do
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --allow -d install --reinstall $PACKAGE | indent
+    apt-get $APT_OPTIONS -y -d install --reinstall $PACKAGE | indent
   fi
 done
 


### PR DESCRIPTION
Fixes https://github.com/heroku/heroku-buildpack-google-chrome/issues/25