### PR TITLE
Adding support for heroku-18

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -67,8 +67,11 @@ case "$stack" in
   "heroku-16")
     PACKAGES="libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk2.0-0 libgtk-3-0 libxinerama1 libcairo-gobject2"
     ;;
+  "heroku-18")
+    PACKAGES="libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk2.0-0 libgtk-3-0 libxinerama1 libcairo-gobject2"
+    ;;
   *)
-    error "STACK must be 'cedar-14' or 'heroku-16', not '$stack.'"
+    error "STACK must be 'cedar-14', 'heroku-16', or 'heroku-18' not '$stack.'"
 esac
 
 indent "Installing Google Chrome from the $channel channel."

--- a/bin/compile
+++ b/bin/compile
@@ -64,10 +64,7 @@ case "$stack" in
   "cedar-14")
     PACKAGES="libxss1"
     ;;
-  "heroku-16")
-    PACKAGES="libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk2.0-0 libgtk-3-0 libxinerama1 libcairo-gobject2"
-    ;;
-  "heroku-18")
+  "heroku-16" | "heroku-18")
     PACKAGES="libxss1 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxfixes3 libxi6 libxtst6 libnss3 libgconf-2-4 libxrandr2 libasound2 libatk1.0-0 libgtk2.0-0 libgtk-3-0 libxinerama1 libcairo-gobject2"
     ;;
   *)


### PR DESCRIPTION
Adding support to chrome buildpack for heroku-18 stack. Tested with in-dyno CI and spins up Chrome accordingly in a Selenium test. 

