### PR TITLE
Purging cache to get around g_log_structured_standard error

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -66,14 +66,20 @@ case "$stack" in
     ;;
   "heroku-16" | "heroku-18")
     # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
-    # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting 
+    # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
     PACKAGES="libx11-xcb1 libxtst6 libnss3 libnspr4 libxss1 libasound2 libatk-bridge2.0-0 libgtk-3-0"
     ;;
   *)
     error "STACK must be 'cedar-14', 'heroku-16', or 'heroku-18' not '$stack.'"
 esac
 
-indent "Installing Google Chrome from the $channel channel."
+if [ ! -f $CACHE_DIR/UPDATED_APT_GET ]; then
+  topic "Purging apt-get cache"
+  rm -rf $CACHE_DIR/apt
+  touch $CACHE_DIR/UPDATED_APT_GET
+fi
+
+topic "Installing Google Chrome from the $channel channel."
 
 PACKAGES="$PACKAGES https://dl.google.com/linux/direct/google-chrome-${channel}_current_amd64.deb"
 


### PR DESCRIPTION
Auto-purge cache to get around the issues seen here: https://github.com/heroku/heroku-buildpack-google-chrome/commit/b8712bf6eb28aa48a89eb1fda451328345ea1d84#comments