### PR TITLE
Adding missing chrome deps

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -67,18 +67,40 @@ case "$stack" in
   "heroku-16" | "heroku-18")
     # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
     # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
-    PACKAGES="libx11-xcb1 libxtst6 libnss3 libnspr4 libxss1 libasound2 libatk-bridge2.0-0 libgtk-3-0"
+    PACKAGES="
+      gconf-service
+      libappindicator1
+      libasound2
+      libatk1.0-0
+      libatk-bridge2.0-0
+      libcairo-gobject2
+      libgconf-2-4
+      libgtk-3-0
+      libnspr4
+      libnss3
+      libx11-xcb1
+      libxcomposite1
+      libxcursor1
+      libxdamage1
+      libxfixes3
+      libxi6
+      libxinerama1
+      libxrandr2
+      libxss1
+      libxtst6
+      fonts-liberation
+    "
     ;;
   *)
     error "STACK must be 'cedar-14', 'heroku-16', or 'heroku-18' not '$stack.'"
 esac
 
-if [ ! -f $CACHE_DIR/PURGED_CACHE ]; then
+if [ ! -f $CACHE_DIR/PURGED_CACHE_V1 ]; then
   topic "Purging cache"
   rm -rf $CACHE_DIR/apt
   rm -rf $CACHE_DIR/archives
   rm -rf $CACHE_DIR/lists
-  touch $CACHE_DIR/PURGED_CACHE
+  touch $CACHE_DIR/PURGED_CACHE_V1
 fi
 
 topic "Installing Google Chrome from the $channel channel."


### PR DESCRIPTION
Added a few more packages and formatted the list. Some of these packages are in the base image but this worked for both build and runtime images.

Also dropping cache to hopefully make it as fresh an apt-get install as we can.