### PR TITLE
Remove warning about Selenium form filling not working from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,6 @@
 This buildpack downloads and installs (headless) Google Chrome from your choice
 of release channels.
 
-While headless Chrome is stable, some use cases (like filling in fields via
-Selenium) require an X window server to be active. For those cases, please
-see the [heroku-xvfb-google-chrome buildpack](https://github.com/heroku/heroku-buildpack-xvfb-google-chrome)
-instead.
-
 ## Channels
 
 You can choose your release channel by specifying `GOOGLE_CHROME_CHANNEL` as


### PR DESCRIPTION
Since form filling does now work:
https://github.com/heroku/heroku-buildpack-xvfb-google-chrome/issues/12#issuecomment-487697429

Fixes #45.