### PR TITLE
Add validator for chrome binary

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -3,6 +3,7 @@
 
 # fail fast
 set -e
+set -o pipefail
 
 # debug
 # set -x
@@ -182,3 +183,6 @@ cat <<EOF >$BUILD_DIR/.profile.d/010_google-chrome.sh
 export GOOGLE_CHROME_BIN="\$HOME/.apt/opt/google/$BIN"
 export GOOGLE_CHROME_SHIM="\$HOME/.apt/usr/bin/$SHIM"
 EOF
+
+topic "Validating google-chrome binary"
+$BUILD_DIR/.apt/opt/google/$BIN --version | indent


### PR DESCRIPTION
Hi Heroku,

I added validator for chrome binary. We can avoid missing libs error such as #56.

This change gives the following logs.

```
remote: -----> Validating google-chrome binary
remote:        Google Chrome 74.0.3729.169 unknown
```

You can try the invalid case with the following patch.

```patch
diff --git a/bin/compile b/bin/compile
index 4b69ba2..28671ad 100755
--- a/bin/compile
+++ b/bin/compile
@@ -185,4 +185,5 @@ export GOOGLE_CHROME_SHIM="\$HOME/.apt/usr/bin/$SHIM"
 EOF
 
 topic "Validating google-chrome binary"
+rm $BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/libnss3.so
 $BUILD_DIR/.apt/opt/google/$BIN --version | indent
```

Deployment fails with the following error. Users can avoid releasing invalid Chrome binary.

```
remote: -----> Validating google-chrome binary
remote: /tmp/build_4ce8259a990331c321050350bde9d177/.apt/opt/google/chrome/chrome: error while loading shared libraries: libnss3.so: cannot open shared object file: No such file or directory
remote:  !     Push rejected, failed to compile Google Chrome app.
remote:
remote:  !     Push failed
```