### PR TITLE
GOOGLE_CHROME_SHIM now responds to --version and --product-version.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -171,7 +171,13 @@ BIN_DIR=$BUILD_DIR/.apt/usr/bin
 rm $BIN_DIR/$SHIM
 cat <<EOF >$BIN_DIR/$SHIM
 #!/usr/bin/env bash
-exec \$HOME/.apt/opt/google/$BIN --headless --no-sandbox --disable-gpu --remote-debugging-port=9222 \$@
+if [ $1 = "--version" ]; then
+  exec \$HOME/.apt/opt/google/$BIN --version
+elif [ $1 = "--product-version" ]; then
+  exec \$HOME/.apt/opt/google/$BIN --product-version
+else
+  exec \$HOME/.apt/opt/google/$BIN --headless --no-sandbox --disable-gpu --remote-debugging-port=9222 \$@
+fi
 EOF
 chmod +x $BIN_DIR/$SHIM
 cp $BIN_DIR/$SHIM $BIN_DIR/google-chrome


### PR DESCRIPTION
This change adds out-of-the-box compatibility with the [`webdrivers`](https://github.com/titusfortner/webdrivers) gem, which apparently quite a few Heroku users are using. Currently, the users have to use a [workaround](https://github.com/titusfortner/webdrivers/wiki/Heroku-buildpack-google-chrome) in their project to get the Chrome version from `$GOOGLE_CHROME_BIN`, so that `webdrivers` can download the appropriate version of `chromedriver`, and then switch back to `$GOOGLE_CHROME_SHIM` to launch Chrome.

See https://github.com/titusfortner/webdrivers/pull/40, https://github.com/titusfortner/webdrivers/issues/72, and https://github.com/titusfortner/webdrivers/issues/134.

This simple change will provide the convenience of not needing any hacks to make the two work :).