### PR TITLE
Fix missing dependencies for Google Chrome 81

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -74,11 +74,14 @@ case "$stack" in
       libatk1.0-0
       libatk-bridge2.0-0
       libcairo-gobject2
+      libdrm-dev
+      libgbm-dev
       libgconf-2-4
       libgtk-3-0
       libnspr4
       libnss3
       libx11-xcb1
+      libxcb-dri3-0
       libxcomposite1
       libxcursor1
       libxdamage1

--- a/bin/compile
+++ b/bin/compile
@@ -74,8 +74,8 @@ case "$stack" in
       libatk1.0-0
       libatk-bridge2.0-0
       libcairo-gobject2
-      libdrm-dev
-      libgbm-dev
+      libdrm2
+      libgbm1
       libgconf-2-4
       libgtk-3-0
       libnspr4


### PR DESCRIPTION
Google Chrome 81 is out, and it breaks this buildpack because some dependencies are missing.
I didn't check for the heroku-14 stack. I'll try to do it soon.

Fix #84 

--- 

EDIT: I put dev dependencies, is not the proper fix. I'll update it soon.