### PR TITLE
Test the buildpack in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+support/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,27 @@
-sudo: false
-script: exit 0
+language: bash
+services:
+  - docker
+env:
+  - STACK=cedar-14 GOOGLE_CHROME_CHANNEL=stable
+  - STACK=cedar-14 GOOGLE_CHROME_CHANNEL=beta
+  - STACK=cedar-14 GOOGLE_CHROME_CHANNEL=unstable
+
+  - STACK=heroku-16 GOOGLE_CHROME_CHANNEL=stable
+  - STACK=heroku-16 GOOGLE_CHROME_CHANNEL=beta
+  - STACK=heroku-16 GOOGLE_CHROME_CHANNEL=unstable
+
+  - STACK=heroku-18 GOOGLE_CHROME_CHANNEL=stable
+  - STACK=heroku-18 GOOGLE_CHROME_CHANNEL=beta
+  - STACK=heroku-18 GOOGLE_CHROME_CHANNEL=unstable
+
+  # Test relying on the buildpack's default Chrome channel.
+  - STACK=heroku-18
+script:
+  - ./support/test.sh "${STACK}"
+jobs:
+  allow_failures:
+    # Cedar-14 currently fails with:
+    # "error while loading shared libraries: libgbm.so.1".
+    - env: STACK=cedar-14 GOOGLE_CHROME_CHANNEL=stable
+    - env: STACK=cedar-14 GOOGLE_CHROME_CHANNEL=beta
+    - env: STACK=cedar-14 GOOGLE_CHROME_CHANNEL=unstable

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+ARG STACK
+ARG GOOGLE_CHROME_CHANNEL
+
+# Emulate the platform where root access is not available
+RUN useradd -m -d /app non-root-user
+RUN mkdir -p /app /cache /env
+RUN chown non-root-user /app /cache /env
+USER non-root-user
+
+RUN [ -z "${GOOGLE_CHROME_CHANNEL}" ] || echo "${GOOGLE_CHROME_CHANNEL}" > /env/GOOGLE_CHROME_CHANNEL
+COPY --chown=non-root-user . /buildpack
+WORKDIR /app
+
+# Sanitize the environment seen by the buildpack, to prevent reliance on
+# environment variables that won't be present when it's run by Heroku CI.
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/detect /app
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /app /cache /env

--- a/support/test.sh
+++ b/support/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[ $# -eq 1 ] || { echo "Usage: $0 STACK"; exit 1; }
+
+STACK="${1}"
+
+if [[ "${STACK}" == "cedar-14" ]]; then
+    BASE_IMAGE="heroku/${STACK/-/:}"
+else
+    BASE_IMAGE="heroku/${STACK/-/:}-build"
+fi
+
+OUTPUT_IMAGE="google-chrome-test-${STACK}"
+
+echo "Building buildpack on stack ${STACK}..."
+
+docker build \
+    --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+    --build-arg "STACK=${STACK}" \
+    ${GOOGLE_CHROME_CHANNEL:+--build-arg "GOOGLE_CHROME_CHANNEL=${GOOGLE_CHROME_CHANNEL}"} \
+    -t "${OUTPUT_IMAGE}" \
+    .
+
+echo "Checking Google Chrome can start and aliases exist..."
+
+TEST_COMMAND="for alias in google-chrome{,-${GOOGLE_CHROME_CHANNEL:-stable}} \${GOOGLE_CHROME_BIN} \${GOOGLE_CHROME_SHIM}; do \${alias} --version; done"
+docker run --rm -it "${OUTPUT_IMAGE}" bash -c "set -ex && for f in .profile.d/*; do source \"\$f\"; done && ${TEST_COMMAND}"
+
+echo "Success!"


### PR DESCRIPTION
Since previously the Travis run was a no-op, and we're about to add support for a new stack (in the next PR), which would be good to be able to test properly.

Uses an approach similar to that in:
https://github.com/heroku/heroku-buildpack-ci-postgresql

The Cedar-14 runs have been marked as `allow_failures`, since Chrome currently fails to start due to:
`error while loading shared libraries: libgbm.so.1`

Fixing the buildpack on Cedar-14 is out of scope for this PR, plus the stack is EOL and no-one has opened a support ticket for broken of Cedar-14 support yet. I'm leaving the Cedar-14 entries in the matrix to (a) make the current state clearer, (b) make it easier for an external contributor to fix if desired.

Refs [W-7502526](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007oGhWIAU/view).