### PR TITLE
Add support for Heroku-20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
   - STACK=heroku-18 GOOGLE_CHROME_CHANNEL=beta
   - STACK=heroku-18 GOOGLE_CHROME_CHANNEL=unstable
 
+  - STACK=heroku-20 GOOGLE_CHROME_CHANNEL=stable
+  - STACK=heroku-20 GOOGLE_CHROME_CHANNEL=beta
+  - STACK=heroku-20 GOOGLE_CHROME_CHANNEL=unstable
+
   # Test relying on the buildpack's default Chrome channel.
   - STACK=heroku-18
 script:

--- a/bin/compile
+++ b/bin/compile
@@ -64,7 +64,7 @@ case "$stack" in
   "cedar-14")
     PACKAGES="libxss1"
     ;;
-  "heroku-16" | "heroku-18")
+  "heroku-16" | "heroku-18" | "heroku-20")
     # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
     # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
     PACKAGES="
@@ -95,7 +95,7 @@ case "$stack" in
     "
     ;;
   *)
-    error "STACK must be 'cedar-14', 'heroku-16', or 'heroku-18' not '$stack.'"
+    error "STACK must be 'cedar-14', 'heroku-16', 'heroku-18' or 'heroku-20', not '$stack'."
 esac
 
 if [ ! -f $CACHE_DIR/PURGED_CACHE_V1 ]; then


### PR DESCRIPTION
This adds support for the upcoming Heroku-20 stack.

I confirmed the output from `ldd $GOOGLE_CHROME_BIN | grep not` from within the Docker container was identical for Heroku-18 and Heroku-20, ie: there are no additional (or fewer) shared libraries required.

Fixes [W-7502526](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000007oGhWIAU/view).