### PR TITLE
Add CHROME_VERSION envvar for later buildpacks

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -160,9 +160,10 @@ export INCLUDE_PATH="$BUILD_DIR/.apt/usr/include:$BUILD_DIR/.apt/usr/include/x86
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 export PKG_CONFIG_PATH="$BUILD_DIR/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/i386-linux-gnu/pkgconfig:$BUILD_DIR/.apt/usr/lib/pkgconfig:$PKG_CONFIG_PATH"
+export CHROME_VERSION=$($BUILD_DIR/.apt/opt/google/$BIN --product-version)
 
 #give environment to later buildpacks
-export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH)='  > "$LP_DIR/export"
+export | grep -E -e ' (PATH|LD_LIBRARY_PATH|LIBRARY_PATH|INCLUDE_PATH|CPATH|CPPPATH|PKG_CONFIG_PATH|CHROME_VERSION)='  > "$LP_DIR/export"
 
 topic "Rewrite package-config files"
 find $BUILD_DIR/.apt -type f -ipath '*/pkgconfig/*.pc' | xargs --no-run-if-empty -n 1 sed -i -e 's!^prefix=\(.*\)$!prefix='"$BUILD_DIR"'/.apt\1!g'


### PR DESCRIPTION
#### Reason why I send this PR

Send this PR because lots of https://github.com/heroku/heroku-buildpack-chromedriver users (including me) encountered the chromedirver and Chrome version mismatch problem (`This version of ChromeDriver only supports Chrome version XX`) so often and some of these users even create issues in here:

- https://github.com/heroku/heroku-buildpack-chromedriver/issues/27
- https://github.com/heroku/heroku-buildpack-chromedriver/issues/26
    - https://github.com/heroku/heroku-buildpack-google-chrome/issues/94
- https://github.com/heroku/heroku-buildpack-chromedriver/issues/21
- https://github.com/heroku/heroku-buildpack-google-chrome/issues/82 (potentially related)
- https://github.com/heroku/heroku-buildpack-google-chrome/issues/86

Although heroku-buildpack-chromedriver has a feature which you can set the `CHROMEDIRVER_VERSION` config var in Heroku dashboard to make it install the specific version of chromedriver.
But, It's annoying that if I push my code to Heroku once a while. It will download the new version Chrome and new version chromedriver then this problem shows again. (Same for new users.)
I have to login to the console, check the version of Chrome, modify the `CHROMEDIRVER_VERSION` config var and make Heroku rebuild my app again to solve this problem.

So, I came out with a idea:

"What if heroku-buildpack-chromedriver can install the same version of chromedriver for the Chrome installed by heroku-buildpack-google-chrome automatically?"

At first, I was trying to solve this problem in heroku-buildpack-chromedriver without sending PR to this upstream repo.
But, after spent some time on digging out the code, realizing how it works and testing on my own Heroku app.
I found out I cannot get the version of Chrome installed by heroku-buildpack-google-chrome.
Although it did `export PATH="$BUILD_DIR/.apt/usr/bin:$PATH"` for later buildpacks in https://github.com/heroku/heroku-buildpack-google-chrome/blob/e85ed96d67c05d35fd1488948c16603b4e4b8717/bin/compile#L156-L165 
I thought I could easily use `google-chrome --version` to get it in the heroku-buildpack-chromedriver building process, so I don't need to send a PR to this repo. Since there's a alias 
`$BUILD_DIR/.apt/usr/bin/google-chrome` been created at https://github.com/heroku/heroku-buildpack-google-chrome/blob/e85ed96d67c05d35fd1488948c16603b4e4b8717/bin/compile#L172-L186
But, I was wrong. The problem is that alias points to the `$HOME`. During the building process, all things are still in the `$BUILD_DIR`, not copied to `$HOME` yet. So, I got the error message while testing my patch:

`/tmp/build_04cb8278/.apt/usr/bin/google-chrome: line 3: /app/.apt/opt/google/chrome/chrome: No such file or directory`

I am not sure if late buildpack use the same `$BUILD_DIR` as the previous buildpack, But even if so, I had to call `$BUILD_DIR/.apt/opt/google/$BIN --product-version` to get the version of Chrome. The problem is `$BIN` is decided by the `$channel` in this repo: https://github.com/heroku/heroku-buildpack-google-chrome/blob/e85ed96d67c05d35fd1488948c16603b4e4b8717/bin/compile#L41-L58
I don't think it's a good idea to find all the possible executables in a downstream repo. So, that's the reason why I am here to send this PR.

---

#### Detail 

So, I have to get the `CRHOME_VERSION` from `$BUILD_DIR/.apt/opt/google/$BIN --product-version` which is the absolute path of the downloaded Chrome.
Export it for the later buildpacks, which is heroku-buildpack-chromedriver here. So, it will know what version of chromedriver to download. (Of course, Need to modify the code of heroku-buildpack-chromedirver.)

---

#### Review

After using my patches of these two repos to build my Heroku App:

- <https://github.com/M157q/heroku-buildpack-google-chrome/tree/add-chrome_version-envvar-for-later-buildpacks>
- <https://github.com/M157q/heroku-buildpack-chromedriver/tree/find-same-version-as-chrome>

It works like a charm on Heroku-18.
Here's a part of the build log:
![20200910_16:12:19](https://user-images.githubusercontent.com/1645228/92699661-760abc80-f380-11ea-87d5-f8bd04f89ccc.jpg)

The version of Chrome installed by heroku-buildpack-google-chrome And the version of chromedirver installed by patched heroku-buildpack-chromedriver (app name erased for safety reason):
![20200910_16:15:05](https://user-images.githubusercontent.com/1645228/92700784-cd5d5c80-f381-11ea-8eac-930aa686ca1a.jpg)

---

#### Further

If this PR could be merged, I think it can also solve another PR: https://github.com/heroku/heroku-buildpack-google-chrome/pull/78

Hope this PR could be merged.
Any further discussions are welcome.
Thank you and appreciate your time for reading this long PR description.