### PR TITLE
update packages required to be installed

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -68,30 +68,44 @@ case "$stack" in
     # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
     # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
     PACKAGES="
-      gconf-service
-      libappindicator1
+      ca-certificates
+      fonts-liberation
+      libappindicator3-1
       libasound2
-      libatk1.0-0
       libatk-bridge2.0-0
-      libcairo-gobject2
-      libdrm2
+      libatk1.0-0
+      libc6
+      libcairo2
+      libcups2
+      libdbus-1-3
+      libexpat1
+      libfontconfig1
       libgbm1
-      libgconf-2-4
+      libgcc1
+      libglib2.0-0
       libgtk-3-0
       libnspr4
       libnss3
+      libpango-1.0-0
+      libpangocairo-1.0-0
+      libstdc++6
+      libx11-6
       libx11-xcb1
-      libxcb-dri3-0
+      libxcb1
       libxcomposite1
       libxcursor1
       libxdamage1
+      libxext6
       libxfixes3
       libxi6
-      libxinerama1
       libxrandr2
+      libxrender1
       libxss1
+      libxhsmfence
       libxtst6
-      fonts-liberation
+      lsb-release
+      wget
+      xdg-utils
     "
     ;;
   *)


### PR DESCRIPTION
copied from https://developers.google.com/web/tools/puppeteer/troubleshooting

Chrome 88 also seems to have introduced a dependencyon libxhsmfence as well.