### PR TITLE
Add libxshmfence1 package dependency for Chrome 89.0.4389.72

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -89,6 +89,7 @@ case "$stack" in
       libxi6
       libxinerama1
       libxrandr2
+      libxshmfence1
       libxss1
       libxtst6
       fonts-liberation


### PR DESCRIPTION
Chrome stopped working on Heroku CI for us when this rolled out today https://chromereleases.googleblog.com/2021/

`ldd` says `libxshmfence.so.1 => not found`

Adding `libxshmfence1` solved for our case (`heroku-18` stack)