### PR TITLE
install all packages at once, don't reinstall

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -122,6 +122,7 @@ APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state
 topic "Updating apt caches"
 apt-get $APT_OPTIONS update | indent
 
+PACKAGES_TO_INSTALL=""
 for PACKAGE in $PACKAGES; do
   if [[ $PACKAGE == *deb ]]; then
     PACKAGE_NAME=$(basename $PACKAGE .deb)
@@ -130,10 +131,12 @@ for PACKAGE in $PACKAGES; do
     topic "Fetching $PACKAGE"
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
-    topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
+    topic "Will fetch .debs for $PACKAGE"
+    PACKAGES_TO_INSTALL="$PACKAGES_TO_INSTALL $PACKAGE"
   fi
 done
+topic "Fetch .debs for $PACKAGES_TO_INSTALL"
+apt-get $APT_OPTIONS -y --force-yes -d install $PACKAGES_TO_INSTALL | indent
 
 mkdir -p $BUILD_DIR/.apt
 


### PR DESCRIPTION
1. I'm not sure why the --reinstall is necessary, so I removed it
2. Installing one package at a time is slow - this increases buildpack creation time by about 60s