### PR TITLE
Bugfix dpkg install

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -124,8 +124,7 @@ apt-get $APT_OPTIONS update | indent
 
 for PACKAGE in $PACKAGES; do
   if [[ $PACKAGE == *deb ]]; then
-    PACKAGE_NAME=$(basename $PACKAGE .deb)
-    PACKAGE_FILE=$APT_CACHE_DIR/archives/$PACKAGE_NAME.deb
+    PACKAGE_FILE=$APT_CACHE_DIR/archives/google_chrome.deb
 
     topic "Fetching $PACKAGE"
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent


### PR DESCRIPTION
Heroku CI builds seem currently broken due to dashed file names. 

Using a simple underscore only filename seems to fix this issue.

Error Message:
```
-----> Installing google-chrome-stable_current_amd64.deb
dpkg-deb: error: '/tmp/cache706677882/apt/cache/archives/google-chrome-stable_current_amd64.deb' is not a Debian format archive
```