### PR TITLE
Update compile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -131,7 +131,7 @@ for PACKAGE in $PACKAGES; do
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
+    apt-get $APT_OPTIONS -y --allow -d install --reinstall $PACKAGE | indent
   fi
 done
 


### PR DESCRIPTION
Use --allow instead of --force-yes

simple fix that deletes all "W: --force-yes is deprecated, use one of the options starting with --allow instead." warnings