### PR TITLE
Remove support for Cedar-14 and Heroku-16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ workflows:
           matrix:
             parameters:
               channel: [stable, beta, unstable]
-              stack: [heroku-16, heroku-18, heroku-20]
+              stack: [heroku-18, heroku-20]
       - test: #default
           channel: ""
-          stack: heroku-18
+          stack: heroku-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Removed support for Cedar-14 and Heroku-16.
 - Switched to CircleCI
 - Corrected `$GOOGLE_CHROME_SHIM` and `$GOOGLE_CHROME_BIN` to use correct paths both at runtime and during tests.
 - Added `$GOOGLE_CHROME_SHIM` variable to prevent users from needing to hard-

--- a/bin/compile
+++ b/bin/compile
@@ -57,14 +57,9 @@ case "$channel" in
     ;;
 esac
 
-stack=${STACK:-heroku-16}
-
 # Install correct dependencies according to $STACK
-case "$stack" in
-  "cedar-14")
-    PACKAGES="libxss1"
-    ;;
-  "heroku-16" | "heroku-18" | "heroku-20")
+case "${STACK}" in
+  "heroku-18" | "heroku-20")
     # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
     # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
     PACKAGES="
@@ -96,7 +91,7 @@ case "$stack" in
     "
     ;;
   *)
-    error "STACK must be 'cedar-14', 'heroku-16', 'heroku-18' or 'heroku-20', not '$stack'."
+    error "STACK must be 'heroku-18' or 'heroku-20', not '${STACK}'."
 esac
 
 if [ ! -f $CACHE_DIR/PURGED_CACHE_V1 ]; then


### PR DESCRIPTION
Since it's no longer possible to build with those stacks on the Heroku platform, as the build system for them no longer exists.

See:
https://help.heroku.com/SMQ1J712/cedar-14-end-of-life-faq
https://help.heroku.com/0S5P41DC/heroku-16-end-of-life-faq

Fixes #109.