### PR TITLE
Prevent from any forced shared libraries injection in created shims.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## 2022-03-24
+### Changed
+- Explicitly unset LD_PRELOAD env variable.
+
+## Pre 2022-03-24
+### Changed
 - Removed support for Cedar-14 and Heroku-16.
 - Switched to CircleCI
 - Corrected `$GOOGLE_CHROME_SHIM` and `$GOOGLE_CHROME_BIN` to use correct paths both at runtime and during tests.

--- a/bin/compile
+++ b/bin/compile
@@ -170,6 +170,10 @@ BIN_DIR=$BUILD_DIR/.apt/usr/bin
 rm $BIN_DIR/$SHIM
 cat <<EOF >$BIN_DIR/$SHIM
 #!/usr/bin/env bash
+
+# prevent from any forced shared libraries injection
+unset LD_PRELOAD
+
 if [ \$1 = "--version" ]; then
   exec \$HOME/.apt/opt/google/$BIN --version
 elif [ \$1 = "--product-version" ]; then


### PR DESCRIPTION
This PR was originally submitted by @lukgni at https://github.com/heroku/heroku-buildpack-google-chrome/pull/125

The original PR was blocked by PR checks that prevented changes without touching CHANGELOG. We couldn't modify the original PR, so we just replicated the change here.