### PR TITLE
Add support for Heroku-22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,5 @@
 # Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
-orbs:
-  docker: circleci/docker@1.5.0
 jobs:
   test:
     parameters:
@@ -13,10 +11,11 @@ jobs:
       STACK: << parameters.stack >>
       GOOGLE_CHROME_CHANNEL: << parameters.channel >>
     docker:
-      - image: cimg/base:2020.01
+      - image: cimg/base:stable
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+          version: 20.10.11
       - checkout
       - run:
           name: "Running test"
@@ -29,7 +28,7 @@ workflows:
           matrix:
             parameters:
               channel: [stable, beta, unstable]
-              stack: [heroku-18, heroku-20]
+              stack: [heroku-18, heroku-20, heroku-22]
       - test: #default
           channel: ""
-          stack: heroku-20
+          stack: heroku-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Added support for Heroku-22.
 
 ## 2022-03-24
 ### Changed

--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,7 @@ esac
 
 # Install correct dependencies according to $STACK
 case "${STACK}" in
-  "heroku-18" | "heroku-20")
+  "heroku-18" | "heroku-20" | "heroku-22")
     # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
     # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
     PACKAGES="
@@ -91,7 +91,7 @@ case "${STACK}" in
     "
     ;;
   *)
-    error "STACK must be 'heroku-18' or 'heroku-20', not '${STACK}'."
+    error "STACK must be 'heroku-18', 'heroku-20' or 'heroku-22', not '${STACK}'."
 esac
 
 if [ ! -f $CACHE_DIR/PURGED_CACHE_V1 ]; then

--- a/support/test.sh
+++ b/support/test.sh
@@ -5,13 +5,7 @@ set -euo pipefail
 [ $# -eq 1 ] || { echo "Usage: $0 STACK"; exit 1; }
 
 STACK="${1}"
-
-if [[ "${STACK}" == "cedar-14" ]]; then
-    BASE_IMAGE="heroku/${STACK/-/:}"
-else
-    BASE_IMAGE="heroku/${STACK/-/:}-build"
-fi
-
+BASE_IMAGE="heroku/${STACK/-/:}-build"
 OUTPUT_IMAGE="google-chrome-test-${STACK}"
 
 echo "Building buildpack on stack ${STACK}..."


### PR DESCRIPTION
And also:
* Bump some CI image/Docker versions / remove unused orb.
* Remove a testing script Cedar-14 remnant.

I've confirmed that the output from `ldd chrome | grep not` (when the Chrome deb is unpacked in the stack stack image, prior to the vendored libs being provided) is the same for Heroku-22 as when run on Heroku-20 - so there are no additional packages that need adding for Heroku-22.

GUS-W-10346743.