### PR TITLE
Release new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/)
-and this project adheres to [Semantic Versioning](http://semver.org/).
-
 ## [Unreleased]
-### Changed
+
+## 2022-05-19
 - Added support for Heroku-22.
 
-## 2022-03-24
-### Changed
-- Explicitly unset LD_PRELOAD env variable.
+## 2022-03-30
+- Fixed bug where arguments with spaces don't work.
 
-## Pre 2022-03-24
-### Changed
+## 2022-03-29
+- Explicitly unset `LD_PRELOAD` env variable.
+
+## 2022-01-04
 - Removed support for Cedar-14 and Heroku-16.
-- Switched to CircleCI
-- Corrected `$GOOGLE_CHROME_SHIM` and `$GOOGLE_CHROME_BIN` to use correct paths both at runtime and during tests.
-- Added `$GOOGLE_CHROME_SHIM` variable to prevent users from needing to hard-
-  code the shim location.


### PR DESCRIPTION
And fix up the changelog for previous releases, based on:

```
$ h buildpacks:versions heroku/google-chrome | head -n6
Version  Released At               Status
───────  ────────────────────────  ─────────
11       2022-03-30T00:15:48.358Z  published
10       2022-03-29T15:46:55.193Z  published
9        2022-01-04T10:51:11.345Z  published
8        2021-03-03T21:44:25.554Z  published
```