### PR TITLE
Remove --force-yes and don't replace with --allow

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -126,7 +126,7 @@ for PACKAGE in $PACKAGES; do
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
+    apt-get $APT_OPTIONS -y -d install --reinstall $PACKAGE | indent
   fi
 done
 


### PR DESCRIPTION
Neither `--force-yes` or `--allow` are required due to the existence of `-y`. Both `--force-yes` and `--allow` will error and/or warn.