### PR TITLE
dpalmer/6413_get_Chrome_chromedriver_packages_from_S3

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -111,8 +111,6 @@ fi
 
 topic "Installing Google Chrome from the $channel channel."
 
-PACKAGES="$PACKAGES https://lumint-utils.s3.us-east-2.amazonaws.com/google_chrome_${chrome_version}.deb"
-
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
 
@@ -136,6 +134,10 @@ for PACKAGE in $PACKAGES; do
     apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
   fi
 done
+
+aws s3api get-object --bucket $ENV_DIR/S3_BUCKET_URL --key chrome/google-chrome-stable_${chrome_version}.deb $CACHE_DIR/google-chrome.deb --region $ENV_DIR/S3_REGION
+
+dpkg -i $CACHE_DIR/google_chrome.deb
 
 mkdir -p $BUILD_DIR/.apt
 

--- a/bin/compile
+++ b/bin/compile
@@ -182,7 +182,7 @@ if [ \$1 = "--version" ]; then
 elif [ \$1 = "--product-version" ]; then
   exec \$HOME/.apt/opt/google/$BIN --product-version
 else
-  exec \$HOME/.apt/opt/google/$BIN --headless --no-sandbox --disable-gpu --remote-debugging-port=9222 \$@
+  exec \$HOME/.apt/opt/google/$BIN \$@
 fi
 EOF
 chmod +x $BIN_DIR/$SHIM

--- a/bin/compile
+++ b/bin/compile
@@ -38,6 +38,12 @@ else
   channel=stable
 fi
 
+if [ -f $ENV_DIR/CHROMEDRIVER_VERSION ]; then
+  chrome_version=$(cat $ENV_DIR/CHROMEDRIVER_VERSION)
+else
+  error "No CHROMEDRIVER_VERSION setup"
+fi
+
 # Setup bin and shim locations for desired channel, and detect invalid channels
 case "$channel" in
   "stable")
@@ -105,7 +111,7 @@ fi
 
 topic "Installing Google Chrome from the $channel channel."
 
-PACKAGES="$PACKAGES https://lumint-utils.s3.us-east-2.amazonaws.com/google_chrome_75.0.3770.90.deb"
+PACKAGES="$PACKAGES https://lumint-utils.s3.us-east-2.amazonaws.com/google_chrome_${chrome_version}.deb"
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"

--- a/bin/compile
+++ b/bin/compile
@@ -70,7 +70,7 @@ case "$stack" in
   "cedar-14")
     PACKAGES="libxss1"
     ;;
-  "heroku-16" | "heroku-18")
+  "heroku-16" | "heroku-18" | "heroku-20")
     # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
     # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
     PACKAGES="
@@ -98,7 +98,7 @@ case "$stack" in
     "
     ;;
   *)
-    error "STACK must be 'cedar-14', 'heroku-16', or 'heroku-18' not '$stack.'"
+    error "STACK must be 'cedar-14', 'heroku-16', 'heroku-18' or 'heroku-20' not '$stack.'"
 esac
 
 if [ ! -f $CACHE_DIR/PURGED_CACHE_V1 ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -105,7 +105,7 @@ fi
 
 topic "Installing Google Chrome from the $channel channel."
 
-PACKAGES="$PACKAGES https://dl.google.com/linux/direct/google-chrome-${channel}_current_amd64.deb"
+PACKAGES="$PACKAGES https://lumint-utils.s3.us-east-2.amazonaws.com/google_chrome_75.0.3770.90.deb"
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"


### PR DESCRIPTION
- Closes [6413](https://github.com/lumint-corporation/lumint/issues/6413)
 - by updating the compile script to get chrome from s3 rather than a link that doesn't exist anymore.